### PR TITLE
Fix for edit project to use id and not name

### DIFF
--- a/caper/caper/views.py
+++ b/caper/caper/views.py
@@ -741,15 +741,17 @@ def edit_project_page(request, project_name):
 
         form_dict['project_members'] = create_user_list(form_dict['project_members'], get_current_user(request))
 
+
         if 'file' in form_dict:
             runs = samples_to_dict(form_dict['file'])
         else:
             runs = 0
         if check_project_exists(project_name):
+
             current_runs = project['runs']
             if runs != 0:
                 current_runs.update(runs)
-            query = {'project_name': project_name}
+            query = {'_id': ObjectId(project_name)}
             new_val = { "$set": {'runs' : current_runs, 'description': form_dict['description'], 'date': get_date(),
                                  'private': form_dict['private'], 'project_members': form_dict['project_members'],
                                  'Oncogenes': get_project_oncogenes(current_runs)} }


### PR DESCRIPTION
Caught a hole in yesterdays checkin.  Edit was querying by project name not id