### PR TITLE
The scrollbar was because of a race between bootstrap and datatables …

### DIFF
--- a/caper/templates/pages/sample.html
+++ b/caper/templates/pages/sample.html
@@ -4,6 +4,9 @@
 <script>
     $(document).ready( function () {
         $('#myTable2').DataTable({
+            "drawCallback": function( settings ) {
+                $("#usersTable").wrap( "<div class='table-responsive'></div>" );
+            }
         }
         );
     } );
@@ -254,12 +257,10 @@
 
 
 
-<div style="margin-top:25px; padding: 25px; border: 0.5px solid grey">
+<div class="container" style="margin-top:25px; padding: 25px; border: 0.5px solid grey">
     <h3>Features Table</h3>
-    <!-- <div style="text-align:right; padding-bottom:1em;">
-        <button type="submit">Download selected features</button>
-    </div> -->
-    <div class="table-responsive">
+
+
         <table id='myTable2' class="table table-hover table-sm">
             <thead>
                 <tr>
@@ -302,7 +303,7 @@
                 {% endif %}
             </tbody>
         </table>
-    </div>
+
 </div>
 <style>
     .thumbnail img{


### PR DESCRIPTION
…drawing their respective wrappers.  Here bootstrap was first, drawing (and sizing) its wrapper dive before datatables populated.  Fix is to ensure datatables draws first and then adds the table-responsive div https://datatables.net/forums/discussion/29738/bootstrap-responsive-unnecessary-scroll-bar